### PR TITLE
Nick tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Added
+* Nicks (or usernames) are now saved when a member is updated
+* Join and part messages now show nickname or previous name where applicable
 
 
 ## [1.0.1] - 2020-06-03

--- a/actions/joinpart.go
+++ b/actions/joinpart.go
@@ -10,7 +10,12 @@ import (
 )
 
 func onJoin(s *dg.Session, m *dg.GuildMemberAdd) {
-	s.ChannelMessageSend(getChannel(s, m.GuildID), fmt.Sprintf("<@%s> has joined! :wave:", m.User.ID))
+	nick, msg := "", "<@%s> has joined! :wave:"
+	if nickIsCached(m.GuildID, m.User.ID) {
+		msg += "\nLooks like they've been here before, too! Previously they were known as %s."
+		nick = currentNick(m.GuildID, m.User.ID)
+	}
+	s.ChannelMessageSend(getChannel(s, m.GuildID), fmt.Sprintf(msg, m.User.ID, nick))
 }
 
 func onChange(s *dg.Session, m *dg.GuildMemberUpdate) {

--- a/actions/joinpart.go
+++ b/actions/joinpart.go
@@ -10,11 +10,12 @@ import (
 )
 
 func onJoin(s *dg.Session, m *dg.GuildMemberAdd) {
-	msg, nick := "<@%s> has joined! :wave:%s", currentNick(m.GuildID, m.User.ID)
+	msg, nick, status := "<@%s> has %s! :wave:%s", currentNick(m.GuildID, m.User.ID), "joined"
 	if nick != "" {
 		nick = "\nYou may remember them as " + nick
+		status = "returned"
 	}
-	s.ChannelMessageSend(getChannel(s, m.GuildID), fmt.Sprintf(msg, m.User.ID, nick))
+	s.ChannelMessageSend(getChannel(s, m.GuildID), fmt.Sprintf(msg, m.User.ID, status, nick))
 }
 
 func onChange(s *dg.Session, m *dg.GuildMemberUpdate) {

--- a/actions/joinpart.go
+++ b/actions/joinpart.go
@@ -12,8 +12,12 @@ import (
 func onJoin(s *dg.Session, m *dg.GuildMemberAdd) {
 	msg, nick, status := "<@%s> has %s! :wave:%s", currentNick(m.GuildID, m.User.ID), "joined"
 	if nick != "" {
-		nick = "\nYou may remember them as " + nick
 		status = "returned"
+		if nick == m.User.Username {
+			nick = ""
+		} else {
+			nick = "\nYou may remember them as " + nick
+		}
 	}
 	s.ChannelMessageSend(getChannel(s, m.GuildID), fmt.Sprintf(msg, m.User.ID, status, nick))
 }
@@ -28,7 +32,9 @@ func onChange(s *dg.Session, m *dg.GuildMemberUpdate) {
 
 func onPart(s *dg.Session, m *dg.GuildMemberRemove) {
 	nick := currentNick(m.GuildID, m.User.ID)
-	if nick != "" {
+	if nick == m.User.Username {
+		nick = ""
+	} else if nick != "" {
 		nick = " (" + nick + ")"
 	}
 	s.ChannelMessageSend(getChannel(s, m.GuildID), fmt.Sprintf(

--- a/actions/joinpart.go
+++ b/actions/joinpart.go
@@ -61,6 +61,11 @@ func currentNick(g string, u string) string {
 }
 
 func saveNick(guildID string, u *dg.User, nick string) {
+	if nick == "" {
+		fmt.Println("\nNick was removed, saving username instead.")
+		nick = u.Username
+	}
+
 	path := filepath.Join("./storage/guilds", guildID, "members", u.ID)
 	err := os.MkdirAll(path, 0700)
 	if err != nil {

--- a/actions/joinpart.go
+++ b/actions/joinpart.go
@@ -2,6 +2,9 @@ package actions
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 
 	dg "github.com/bwmarrin/discordgo"
 )
@@ -11,7 +14,7 @@ func onJoin(s *dg.Session, m *dg.GuildMemberAdd) {
 }
 
 func onChange(s *dg.Session, m *dg.GuildMemberUpdate) {
-	s.ChannelMessageSend(getChannel(s, m.GuildID), fmt.Sprintf("@%s#%s has a new nick: %s", m.User.Username, m.User.Discriminator, m.Nick))
+	saveNick(m.GuildID, m.User, m.Nick)
 }
 
 func onPart(s *dg.Session, m *dg.GuildMemberRemove) {
@@ -22,4 +25,20 @@ func getChannel(s *dg.Session, guildID string) string {
 	channels, _ := s.GuildChannels(guildID)
 
 	return channels[1].ID
+}
+
+func saveNick(guildID string, u *dg.User, nick string) {
+	path := filepath.Join("./storage/guilds", guildID, "members", u.ID)
+	err := os.MkdirAll(path, 0700)
+	if err != nil {
+		fmt.Println("\nError: Couldn't create directory "+path, err)
+		return
+	}
+
+	err = ioutil.WriteFile(filepath.Join(path, "nick.txt"), []byte(nick), 0644)
+	if err != nil {
+		fmt.Println("\nError: Couldn't write nick.txt", err)
+	} else {
+		fmt.Printf("\nWritten new nick for @%s#%s: %s\n", u.Username, u.Discriminator, nick)
+	}
 }

--- a/actions/joinpart.go
+++ b/actions/joinpart.go
@@ -10,10 +10,9 @@ import (
 )
 
 func onJoin(s *dg.Session, m *dg.GuildMemberAdd) {
-	nick, msg := "", "<@%s> has joined! :wave:"
-	if nickIsCached(m.GuildID, m.User.ID) {
-		msg += "\nLooks like they've been here before, too! Previously they were known as %s."
-		nick = currentNick(m.GuildID, m.User.ID)
+	msg, nick := "<@%s> has joined! :wave:%s", currentNick(m.GuildID, m.User.ID)
+	if nick != "" {
+		nick = "\nYou may remember them as " + nick
 	}
 	s.ChannelMessageSend(getChannel(s, m.GuildID), fmt.Sprintf(msg, m.User.ID, nick))
 }
@@ -27,9 +26,9 @@ func onChange(s *dg.Session, m *dg.GuildMemberUpdate) {
 }
 
 func onPart(s *dg.Session, m *dg.GuildMemberRemove) {
-	nick := ""
-	if nickIsCached(m.GuildID, m.User.ID) {
-		nick = " (" + currentNick(m.GuildID, m.User.ID) + ")"
+	nick := currentNick(m.GuildID, m.User.ID)
+	if nick != "" {
+		nick = " (" + nick + ")"
 	}
 	s.ChannelMessageSend(getChannel(s, m.GuildID), fmt.Sprintf(
 		"<@%s>%s has left :slight_frown:", m.User.ID, nick))

--- a/actions/joinpart.go
+++ b/actions/joinpart.go
@@ -10,6 +10,10 @@ func onJoin(s *dg.Session, m *dg.GuildMemberAdd) {
 	s.ChannelMessageSend(getChannel(s, m.GuildID), fmt.Sprintf("<@%s> has joined! :wave:", m.User.ID))
 }
 
+func onChange(s *dg.Session, m *dg.GuildMemberUpdate) {
+	s.ChannelMessageSend(getChannel(s, m.GuildID), fmt.Sprintf("@%s#%s has a new nick: %s", m.User.Username, m.User.Discriminator, m.Nick))
+}
+
 func onPart(s *dg.Session, m *dg.GuildMemberRemove) {
 	s.ChannelMessageSend(getChannel(s, m.GuildID), fmt.Sprintf("<@%s> has left :slight_frown:", m.User.ID))
 }

--- a/actions/joinpart.go
+++ b/actions/joinpart.go
@@ -22,7 +22,12 @@ func onChange(s *dg.Session, m *dg.GuildMemberUpdate) {
 }
 
 func onPart(s *dg.Session, m *dg.GuildMemberRemove) {
-	s.ChannelMessageSend(getChannel(s, m.GuildID), fmt.Sprintf("<@%s> has left :slight_frown:", m.User.ID))
+	nick := ""
+	if nickIsCached(m.GuildID, m.User.ID) {
+		nick = " (" + currentNick(m.GuildID, m.User.ID) + ")"
+	}
+	s.ChannelMessageSend(getChannel(s, m.GuildID), fmt.Sprintf(
+		"<@%s>%s has left :slight_frown:", m.User.ID, nick))
 }
 
 func getChannel(s *dg.Session, guildID string) string {

--- a/actions/main.go
+++ b/actions/main.go
@@ -9,6 +9,9 @@ func Register(dg *discord.Session) {
 	dg.AddHandler(func(s *discord.Session, m *discord.GuildMemberAdd) {
 		onJoin(s, m)
 	})
+	dg.AddHandler(func(s *discord.Session, m *discord.GuildMemberUpdate) {
+		onChange(s, m)
+	})
 	dg.AddHandler(func(s *discord.Session, m *discord.GuildMemberRemove) {
 		onPart(s, m)
 	})


### PR DESCRIPTION
Discord only gives you the "current" member object in create/remove (join/part) events, which in the case of remove/part means there is no `Nick` defined as the event seems to fire *after* the member has been removed from the guild.

To get around the quirks while also showing usernames in case somebody renames their account before rejoining, this PR adds a whole ton of stuff for tracking nick and username changes.